### PR TITLE
Refactor navigation and theme utilities

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,21 +1,71 @@
 import * as React from "react";
 import ThemeToggle from "@/components/ThemeToggle";
+import type { NavigationLink } from "@/lib/navigation";
+import { getNavigationLinks, resolveNavHref } from "@/lib/navigation";
+import { cn } from "@/lib/utils";
 
-export default function MobileMenu() {
+type MobileMenuProps = {
+  links?: NavigationLink[];
+};
+
+export default function MobileMenu({ links }: MobileMenuProps) {
+  const items = React.useMemo(() => links ?? getNavigationLinks(), [links]);
   const [open, setOpen] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const handleClick = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 768px)");
+    const closeOnDesktop = () => {
+      if (mediaQuery.matches) {
+        setOpen(false);
+      }
+    };
+
+    mediaQuery.addEventListener("change", closeOnDesktop);
+    return () => mediaQuery.removeEventListener("change", closeOnDesktop);
+  }, []);
 
   return (
-    <div className="flex items-center gap-2 md:hidden relative">
+    <div ref={containerRef} className="flex items-center gap-2 md:hidden relative">
       {/* Theme toggle still works as a child */}
       <ThemeToggle />
 
       {/* Hamburger button */}
       <button
         type="button"
-        aria-controls="mobile-menu"
-        aria-expanded={open}
         onClick={() => setOpen(!open)}
-        className="inline-flex items-center justify-center rounded-md p-2 text-slate-600 hover:text-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-600">
+        className={cn(
+          "inline-flex items-center justify-center rounded-md p-2 text-slate-600 hover:text-amber-600",
+          "focus:outline-none focus:ring-2 focus:ring-amber-600"
+        )}
+        aria-label={open ? "Close navigation menu" : "Open navigation menu"}
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-controls="mobile-menu">
         {/* Hamburger / X icon swap */}
         {open ? (
           <svg
@@ -50,25 +100,17 @@ export default function MobileMenu() {
       {open && (
         <nav
           id="mobile-menu"
+          aria-label="Mobile navigation"
           className="absolute right-0 top-full mt-2 w-40 rounded-lg bg-white shadow-lg dark:bg-slate-900">
-          <a
-            href={import.meta.env.BASE_URL}
-            className="block px-4 py-2 hover:text-amber-600"
-            onClick={() => setOpen(false)}>
-            Home
-          </a>
-          <a
-            href={`${import.meta.env.BASE_URL}recipes`}
-            className="block px-4 py-2 hover:text-amber-600"
-            onClick={() => setOpen(false)}>
-            Recipes
-          </a>
-          <a
-            href={`${import.meta.env.BASE_URL}about`}
-            className="block px-4 py-2 hover:text-amber-600"
-            onClick={() => setOpen(false)}>
-            About
-          </a>
+          {items.map((item) => (
+            <a
+              key={item.path}
+              href={resolveNavHref(item.path)}
+              className="block px-4 py-2 hover:text-amber-600"
+              onClick={() => setOpen(false)}>
+              {item.label}
+            </a>
+          ))}
         </nav>
       )}
     </div>

--- a/src/components/recipes/RecipesIndex.tsx
+++ b/src/components/recipes/RecipesIndex.tsx
@@ -12,6 +12,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { resolveNavHref } from "@/lib/navigation";
 
 /* ---------------- types ---------------- */
 
@@ -199,7 +200,7 @@ export default function RecipesIndex({ items }: Props) {
 
 function RecipeCard({ item }: { item: RecipeItem }) {
   const base = import.meta.env.BASE_URL; // "/nourriture-quotidienne/" on GH Pages
-  const href = `${base}recipes/${item.slug}`;
+  const href = resolveNavHref(`recipes/${item.slug}`);
   const imgSrc = item.image
     ? item.image.startsWith("/")
       ? base + item.image.slice(1)

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,6 +8,8 @@
 import "../styles/global.css";
 import ThemeToggle from "@/components/ThemeToggle";
 import MobileMenu from "@/components/MobileMenu";
+import { getNavigationLinks, resolveNavHref } from "@/lib/navigation";
+import { INLINE_THEME_SCRIPT } from "@/lib/theme";
 
 const {
     title = "Nourriture Quotidienne",
@@ -20,6 +22,7 @@ const {
 const site = typeof Astro.site === "string" ? Astro.site : "";
 const pageTitle = title === "Nourriture Quotidienne" ? title : `${title} · Nourriture Quotidienne`;
 const canonical = site ? new URL(Astro.url.pathname, site).toString() : undefined;
+const navigationLinks = getNavigationLinks();
 ---
 <!DOCTYPE html>
 <html lang="en" class="h-full bg-slate-50 dark:bg-slate-950 text-slate-800 dark:text-slate-100 antialiased">
@@ -41,16 +44,8 @@ const canonical = site ? new URL(Astro.url.pathname, site).toString() : undefine
         <meta name="twitter:description" content={description} />
         {image && <meta name="twitter:image" content={image} />}
 
-            {/* Prevent dark-mode flash */}
-    <script>
-      {`try {
-        const saved = localStorage.getItem('theme');
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (saved === 'dark' || (!saved && prefersDark)) {
-          document.documentElement.classList.add('dark');
-        }
-      } catch (_) {}`}
-    </script>
+        {/* Prevent dark-mode flash */}
+        <script is:inline>{INLINE_THEME_SCRIPT}</script>
     </head>
 
     <body class="min-h-screen flex flex-col">
@@ -61,18 +56,23 @@ const canonical = site ? new URL(Astro.url.pathname, site).toString() : undefine
         <header class="pt-4 border-b border-slate-200/60 dark:border-slate-800/80">
   <div class="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
     <!-- Brand -->
-    <a href={import.meta.env.BASE_URL} class="flex items-center gap-2 font-semibold">
+    <a href={resolveNavHref("/")} class="flex items-center gap-2 font-semibold">
       <span class="tracking-tight">Nourriture Quotidienne</span>
     </a>
 
     <!-- Mobile: Theme toggle + hamburger -->
-    <MobileMenu client:load />
+    <MobileMenu client:load links={navigationLinks} />
 
     <!-- Desktop nav -->
     <nav class="hidden md:flex items-center gap-6 text-sm">
-        <a href={import.meta.env.BASE_URL} class="hover:text-amber-600">Home</a>
-        <a href={`${import.meta.env.BASE_URL}recipes`} class="hover:text-amber-600">Recipes</a>
-        <a href={`${import.meta.env.BASE_URL}about`} class="hover:text-amber-600">About</a>
+        {navigationLinks.map((link) => (
+          <a
+            href={resolveNavHref(link.path)}
+            class="hover:text-amber-600"
+            key={link.path}>
+            {link.label}
+          </a>
+        ))}
       <ThemeToggle client:load />
     </nav>
   </div>

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,44 @@
+export type NavigationLink = {
+  /**
+   * Path relative to the site base URL, e.g. "/" or "recipes".
+   * Leading slashes are optional.
+   */
+  path: string;
+  /**
+   * Text label rendered for the navigation item.
+   */
+  label: string;
+};
+
+const RAW_NAVIGATION_LINKS: NavigationLink[] = [
+  { path: "/", label: "Home" },
+  { path: "recipes", label: "Recipes" },
+  { path: "about", label: "About" },
+];
+
+function normalizeBase(base: string) {
+  return base.endsWith("/") ? base : `${base}/`;
+}
+
+function normalizePath(path: string) {
+  if (!path || path === "/") return "";
+  return path.startsWith("/") ? path.slice(1) : path;
+}
+
+/**
+ * Resolve a relative navigation path to an absolute href taking Astro's base URL into account.
+ */
+export function resolveNavHref(path: string) {
+  const base = typeof import.meta.env.BASE_URL === "string" ? import.meta.env.BASE_URL : "/";
+  const normalizedBase = normalizeBase(base);
+  const normalizedPath = normalizePath(path);
+  return normalizedPath ? `${normalizedBase}${normalizedPath}` : normalizedBase;
+}
+
+/**
+ * Navigation links used across the site.
+ * Exported as a function to keep the structure extensible (e.g. sorting or filtering later).
+ */
+export function getNavigationLinks(): NavigationLink[] {
+  return RAW_NAVIGATION_LINKS.slice();
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,37 @@
+export type Theme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "theme";
+
+export function applyTheme(theme: Theme) {
+  if (typeof document === "undefined") return;
+  document.documentElement.classList.toggle("dark", theme === "dark");
+}
+
+export function readStoredTheme(): Theme | null {
+  if (typeof window === "undefined") return null;
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  return stored === "dark" || stored === "light" ? stored : null;
+}
+
+export function getInitialTheme(): Theme {
+  if (typeof document !== "undefined" && document.documentElement.classList.contains("dark")) {
+    return "dark";
+  }
+
+  if (typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    return "dark";
+  }
+
+  const stored = readStoredTheme();
+  return stored ?? "light";
+}
+
+export const INLINE_THEME_SCRIPT = `try {
+  const saved = localStorage.getItem('${THEME_STORAGE_KEY}');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (saved === 'dark' || (!saved && prefersDark)) {
+    document.documentElement.classList.add('dark');
+  } else {
+    document.documentElement.classList.remove('dark');
+  }
+} catch (_) {}`;

--- a/src/pages/recipes/[slug].astro
+++ b/src/pages/recipes/[slug].astro
@@ -3,6 +3,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getCollection } from "astro:content";
 import { Badge } from "@/components/ui/badge";
 import RecipeSections from "@/components/recipes/RecipeSections.tsx";
+import { resolveNavHref } from "@/lib/navigation";
 
 const imageOnRight = true;
 
@@ -62,7 +63,7 @@ const timeParts = [
               <span class="sr-only">Tags</span>
               {data.tags.map((tag: string) => (
                 <a
-                  href={`${base}tags/${slugify(tag)}`}
+                  href={resolveNavHref(`tags/${slugify(tag)}`)}
                   class="inline-block"
                   title={`View ${tag} recipes`}
                   rel="tag"
@@ -99,7 +100,7 @@ const timeParts = [
             <span class="sr-only">Tags</span>
             {data.tags.map((tag: string) => (
               <a
-                href={`${base}tags/${slugify(tag)}`}
+                href={resolveNavHref(`tags/${slugify(tag)}`)}
                 class="inline-block"
                 title={`View ${tag} recipes`}
                 rel="tag"


### PR DESCRIPTION
## Summary
- centralize site navigation metadata in a shared helper and reuse it across the layout, mobile menu, and recipe views
- improve the mobile menu’s accessibility and responsiveness with shared closing logic and ARIA attributes
- extract theme utilities for consistent inline initialization and toggle behaviour that respects system preference and storage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4e65ab1a48326a746f095606a6c1f